### PR TITLE
feat([replay]): replay after mainnet sync

### DIFF
--- a/ckb-sync-mainnet/ansible/playbook.yml
+++ b/ckb-sync-mainnet/ansible/playbook.yml
@@ -33,6 +33,19 @@
       tags:
         - wait_ckb_synchronization
 
+    # run ckb replay from 1 to tip (based on sync db)
+    - name: Run and Wait for CKB replay
+      block:
+        - name: CKB Replay
+          shell: "CKB_LOG=error {{ ckb_workspace }}/ckb replay --tmp-target=/tmp --profile >> {{ ckb_data_dir }}/logs/run.log"
+        - name: Get TPS
+        - shell: "grep 'End profiling, duration:.*s txs.* tps [0-9]+' {{ ckb_data_dir }}/logs/run.log | awk '{print $8}'"
+          register: ckb_replay_tps
+        - debug:
+            msg: "{{ ckb_replay_tps.stdout }}"
+      tags:
+        - ckb_replay
+
     - name: Report In Brief
       block:
         - name: RPC local_node_info
@@ -64,6 +77,9 @@
         - name: Get node's current time
           shell: "grep -m 1 'block: {{ ckb_sync_target_number }},' {{ ckb_data_dir }}/logs/run.log"
           register: node_current_time
+        - name: ckb replay tps
+          shell: "grep 'End profiling, duration:.*s txs.* tps [0-9]+' {{ ckb_data_dir }}/logs/run.log | awk '{print $8}'"
+          register: ckb_replay_tps
         - name: Append Entry To Report File
           delegate_to: localhost
           vars:
@@ -72,7 +88,8 @@
             version: "{{ rpc_local_node_info.json.result.version }}"
             time: "{{ node_current_time.stdout[0:19] | to_datetime - node_start_time.stdout[0:19] | to_datetime }}"
             speed: "{{ tip | float / (node_current_time.stdout[0:19] | to_datetime - node_start_time.stdout[0:19] | to_datetime).total_seconds() }}"
-            entry: "| {{ version }} | {{ time }} | {{ speed | int }} | {{ tip }} | {{ inventory_hostname }} | {{ network }} |"
+            replay_tps: "{{ ckb_replay_tps.stdout }}"
+            entry: "| {{ version }} | {{ time }} | {{ speed | int }} | {{ tip }} | {{ inventory_hostname }} | {{ network }} | {{ replay_tps | int }} |"
           shell: "echo '{{ entry }}' > {{ inventory_hostname }}.brief.md"
       tags:
         - report_in_brief

--- a/ckb-sync-mainnet/script/sync-mainnet.sh
+++ b/ckb-sync-mainnet/script/sync-mainnet.sh
@@ -116,6 +116,13 @@ function ansible_wait_ckb_synchronization() {
     ansible-playbook playbook.yml -t wait_ckb_synchronization -e "ckb_sync_target_number=$(job_target_tip_number)"
 }
 
+function ansible_ckb_replay() {
+  ansible_config
+
+  cd $ANSIBLE_DIRECTORY
+  ansible-playbook playbook.yml -t ckb_replay
+}
+
 function markdown_report() {
     case "$OSTYPE" in
         darwin*)
@@ -183,8 +190,9 @@ function parse_report_and_inster_to_postgres() {
       speed=$(echo $LINE | awk -F '|' '{print $4}')
       tip=$(echo $LINE | awk -F '|' '{print $5}')
       hostname=$(echo $LINE | awk -F '|' '{print $6}')
-      psql -c "INSERT INTO sync_mainnet_report (github_run_id,time,ckb_version,ckb_commit_id,ckb_commit_time,time_s,speed,tip,hostname)  \
-             VALUES ('$GITHUB_RUN_ID','$time','$ckb_version','$CKB_COMMIT_ID','$CKB_COMMIT_TIME','$time_s','$speed','$tip','$hostname');"
+      replay_tps=$(echo $LINE | awk -F '|' '{print $8}')
+      psql -c "INSERT INTO sync_mainnet_report (github_run_id,time,ckb_version,ckb_commit_id,ckb_commit_time,time_s,speed,tip,hostname,replay_tps)  \
+             VALUES ('$GITHUB_RUN_ID','$time','$ckb_version','$CKB_COMMIT_ID','$CKB_COMMIT_TIME','$time_s','$speed','$tip','$hostname','$replay_tps');"
     done < "$ANSIBLE_DIRECTORY/sync-mainnet.brief.md"
   fi
 }
@@ -215,6 +223,7 @@ function main() {
             rust_build
             ansible_deploy_ckb
             ansible_wait_ckb_synchronization
+            ansible_ckb_replay
             github_add_comment "$(markdown_report)"
             ;;
         "setup")


### PR DESCRIPTION
auto process `ckb replay` from 1 to tip after Sync Mainnet

- whole ckb replay may takes 5 hours(current 6 million height) to more hours.
- after ckb replay,  append output like"End profiling, duration:18000s, txs:554545, tps:120" to run.log 
- set_fact: tps and next step, we could add this field into daily report.