### PR TITLE
fix(replay): fix PR95, correct syntax error

### DIFF
--- a/ckb-sync-mainnet/ansible/playbook.yml
+++ b/ckb-sync-mainnet/ansible/playbook.yml
@@ -37,7 +37,9 @@
     - name: Run and Wait for CKB replay
       block:
         - name: CKB Replay
-          shell: "CKB_LOG=error {{ ckb_workspace }}/ckb replay --tmp-target=/tmp --profile >> {{ ckb_data_dir }}/logs/run.log"
+          shell: "{{ ckb_workspace }}/ckb replay --tmp-target='/tmp' --profile >> {{ ckb_data_dir }}/logs/run.log"
+          enviroment:
+            CKB_LOG: error
         - name: Get TPS
         - shell: "grep 'End profiling, duration:.*s txs.* tps [0-9]+' {{ ckb_data_dir }}/logs/run.log | awk '{print $8}'"
           register: ckb_replay_tps


### PR DESCRIPTION
Fix PR #95 
correct syntax error, when workflow runs, error message as below:
shell: "CKB_LOG=error {{ ckb_workspace }}/ckb replay --tmp-target=/tmp --profile >> {{ ckb_data_dir }}/logs/run.log"
                         ^ here
There appears to be both 'k=v' shorthand syntax and YAML in this task. Only one syntax may be used.

the original statement as:
"CKB_LOG=error {{ ckb_workspace }}/ckb replay --tmp-target=/tmp --profile >> {{ ckb_data_dir }}/logs/run.log"
so change to 
"CKB_LOG='error' {{ ckb_workspace }}/ckb replay --tmp-target='/tmp' --profile >> {{ ckb_data_dir }}/logs/run.log"

But my question is: why yamllint can't detect this error? and the Ansible manual sucks.