### PR TITLE
fix PR95, correct syntax error

### DIFF
--- a/ckb-sync-mainnet/ansible/playbook.yml
+++ b/ckb-sync-mainnet/ansible/playbook.yml
@@ -38,10 +38,10 @@
       block:
         - name: CKB Replay
           shell: "{{ ckb_workspace }}/ckb replay --tmp-target='/tmp' --profile >> {{ ckb_data_dir }}/logs/run.log"
-          enviroment:
+          environment:
             CKB_LOG: error
         - name: Get TPS
-        - shell: "grep 'End profiling, duration:.*s txs.* tps [0-9]+' {{ ckb_data_dir }}/logs/run.log | awk '{print $8}'"
+          shell: "grep 'End profiling, duration:.*s txs.* tps [0-9]+' {{ ckb_data_dir }}/logs/run.log | awk '{print $8}'"
           register: ckb_replay_tps
         - debug:
             msg: "{{ ckb_replay_tps.stdout }}"


### PR DESCRIPTION
Fix #95, #96

- fix spell error: enviro**n**ment
- fix syntax error `shell` 