### PR TITLE
lock ci runner OS version

### DIFF
--- a/.github/workflows/ckb-integration-test.yml
+++ b/.github/workflows/ckb-integration-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "ubuntu-20.04", "macos-11", "windows-2019" ]
       fail-fast: true
       max-parallel: 10
     defaults:


### PR DESCRIPTION
yasm is still broken in windows-latest (windows-2022)