### PR TITLE
add notice for sync-mainnet job

### DIFF
--- a/ckb-sync-mainnet/README.md
+++ b/ckb-sync-mainnet/README.md
@@ -1,5 +1,7 @@
 # CKB Sync-Mainnet Test
 
+This job will compile ckb locally, please use `ubuntu-focal-20.04-amd64` to run the scripts.
+
 Required environment variables:
 
 - `AWS_ACCESS_KEY`


### PR DESCRIPTION
It requires ubuntu-focal-20.04-amd64 to run the script.