### PR TITLE
fix(sync-mainnet): disable replay temporarily

### DIFF
--- a/ckb-sync-mainnet/ansible/playbook.yml
+++ b/ckb-sync-mainnet/ansible/playbook.yml
@@ -101,7 +101,7 @@
             version: "{{ rpc_local_node_info.json.result.version }}"
             time: "{{ node_current_time.stdout[0:19] | to_datetime - node_start_time.stdout[0:19] | to_datetime }}"
             speed: "{{ tip | float / (node_current_time.stdout[0:19] | to_datetime - node_start_time.stdout[0:19] | to_datetime).total_seconds() }}"
-            replay_tps: "{{ ckb_replay_tps.stdout }}"
+            replay_tps: "0"
             entry: "| {{ version }} | {{ time }} | {{ speed | int }} | {{ tip }} | {{ inventory_hostname }} | {{ network }} | {{ replay_tps | int }} |"
           shell: "echo '{{ entry }}' > {{ inventory_hostname }}.brief.md"
       tags:

--- a/ckb-sync-mainnet/script/sync-mainnet.sh
+++ b/ckb-sync-mainnet/script/sync-mainnet.sh
@@ -222,7 +222,6 @@ function main() {
       rust_build
       ansible_deploy_ckb
       ansible_wait_ckb_synchronization
-      ansible_ckb_replay
       github_add_comment "$(markdown_report)"
       ;;
     "setup")


### PR DESCRIPTION
cause the whole process(sync + replay) takes more than 20 hours to finish
we disable `replay` step for now, and will add it again after we have a new way to take `sync + replay` 